### PR TITLE
Streamline promises in store.js

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -2346,9 +2346,7 @@ let WishlistPageClass = (function(){
         let totalOnSale = 0;
         let totalNoPrice = 0;
 
-        for (let key in wishlistData) {
-            if (!wishlistData.hasOwnProperty(key)) { continue; }
-            let game = wishlistData[key];
+        for (let [key, game] of Object.entries(wishlistData)) {
             if (game.subs.length > 0) {
                 totalPrice.value += game.subs[0].price / 100;
 


### PR DESCRIPTION
This is the different-way-to-do-Promises that I mentioned a few days ago.

I'll go through line-by-line explaining what I'm changing.

**+-449:** Added a .catch() handler. In the event of a network error, the promise would have rejected and thrown an exception ("Uncaught rejection"). This just logs it to console.

**+515:** `async` keyword forces the function to return a `Promise`, so `return false;` is effectively `return Promise.resolve(false);` without the extra verbiage.

**-517:** As a general guideline, if you're creating a `Promise` to handle the result of another `Promise` you can chain them, which is what +533 does.

**+540:** Since we're returning the promise returned from this `.then()`, the value stored in the resolved `Promise` back in `AppPageClass.data` will be the value we return from this callback.

**+542:** `throw` causes the `Promise` to reject, added a meaningful error message for the `.catch()` handler to display in the console.

**-546:** Because we're returning the promise from `.getApi()`, if that rejects, the rejection will flow up the chain. As a side note, the `.then(handleDone, handleRejection)` was added for historical reasons, 90% of the time you want to `.then(handleDone).catch(handleRejection)` so handleRejection can handle rejections thrown from inside handleDone.

**+2323:** `async` also allows you to use `await` inside the function, as execution yields when it reaches the `await` and resumes when the `Promise` being `await`-ed resolves or rejects.

**-2338,+2330:** Meaningful error message in the rejection again.

**+2342:** So execution of this function pauses until all the promises resolve. A rejection will throw here and be caught as a rejection in the enclosing handler.

**+2349:** As discussed, more concise iteration over an Object-that-is-a-map.

