### PR TITLE
Shim for Promise.finally() on FF <58

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -126,6 +126,27 @@ let Defaults = (function() {
     return self;
 })();
 
+/**
+ * Shim for Promise.finally() for browsers (Waterfox/FF 56) that don't have it
+ * https://github.com/domenic/promises-unwrapping/issues/18#issuecomment-57801572
+ */
+if (typeof Promise.prototype.finally === 'undefined') {
+    Object.defineProperty(Promise.prototype, 'finally', {
+        'value': function(callback) {
+            var constructor = this.constructor;
+            return this.then(function(value) {
+                return constructor.resolve(callback()).then(function(){
+                    return value;
+                    });
+            }, function(reason) {
+                return constructor.resolve(callback()).then(function(){
+                    console.error(reason);
+                    throw reason;
+                    });
+            });
+        },
+    });
+}
 
 /**
  * Common functions that may be used on any pages


### PR DESCRIPTION
I've tested this on an old portable install of FF 56 dev edition and Waterfox.

Options load and save. I didn't notice any missing Store page features.

There are a bunch of promise rejections that I'm going to try to track down. Unfortunately they look like this in the console:
`uncaught exception: undefined (unknown)`

Resolves tfedor/Enhanced_Steam#7