### PR TITLE
Sanity check e.target in saveOptionFromEvent()

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -246,6 +246,7 @@ let Options = (function(){
 	}
 
 	function saveOptionFromEvent(e) {
+		if (!e.target || !e.target.closest) return; // "blur" fires when the window loses focus
 		let node = e.target.closest("[data-setting]");
 		if (!node) {
 			if (e.target.closest("#store_stores")) {


### PR DESCRIPTION
Noticed this error in FF browser console. Not sure if the "blur" event on the window happens in Chrome as well?