### PR TITLE
Global language has been replaced with Language.getCurrentSteamLanguage()

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1499,7 +1499,7 @@ let EarlyAccess = (function(){
 
         let imageName = "img/overlay/early_access_banner_english.png";
         if (Language.isCurrentLanguageOneOf(["brazilian", "french", "italian", "japanese", "koreana", "polish", "portuguese", "russian", "schinese", "spanish", "tchinese", "thai"])) {
-            imageName = "img/overlay/early_access_banner_" + language + ".png";
+            imageName = "img/overlay/early_access_banner_" + Language.getCurrentSteamLanguage().toLowerCase() + ".png";
         }
         imageUrl = ExtensionLayer.getLocalUrl(imageName);
 


### PR DESCRIPTION
There are currently 13x `img/overlay/early_access_banner_language.png` and 25x possible languages in Language.languages.

Should getCurrentSteamLanguage() always be lowercase?

Resolves tfedor/Enhanced_Steam#12