### PR TITLE
Progress bar error message handling was erroring.

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -410,9 +410,10 @@ let ProgressBar = (function(){
         node.classList.add("error");
         node.setAttribute("title", "");
 
-        let nodeError = node.querySelector(".es_progress_error");
+        let nodeError = node.closest('.es_progress_wrap').querySelector(".es_progress_error");
         if (!nodeError) {
             node.insertAdjacentHTML("afterend", "<div class='es_progress_error'>" + Localization.str.ready.failed + ": <ul></ul></div>");
+            nodeError = node.nextElementSibling;
         }
 
         if (!message) {


### PR DESCRIPTION
`node.querySelector('.es_progress_error')` would always fail, so `nodeError === null` on 425, which throws.

Alternately 413 can be `nodeError = node.nextElementSibling` and 414 `if (!nodeError || !nodeError.matches('.es_progress_error'))`