### PR TITLE
Register multiple keys always had the default error

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1658,7 +1658,7 @@ let RegisterKeyPageClass = (function(){
                     sessionid: User.getSessionId(),
                     product_key: current_key
                 }).then(data => {
-
+                    data = JSON.parse(data);
                     let attempted = current_key;
                     let message = Localization.str.register.default;
                     if (data["success"] == 1) {


### PR DESCRIPTION
On the https://store.steampowered.com/account/registerkey page, succeed or fail the response was "wait 30 minutes and try again"