### PR TITLE
Games that don't have a SteamChart (yet) threw

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1282,7 +1282,7 @@ let AppPageClass = (function(){
 
     function addSteamChart(result) {
         if (this.isDlc()) { return; }
-        if (!SyncedStorage.get("show_steamchart_info", true) || !result.charts || !result.charts.chart) { return; }
+        if (!SyncedStorage.get("show_steamchart_info", true) || !result.charts || !result.charts.chart || !result.charts.chart.peakall) { return; }
 
         let appid = this.appid;
         let chart = result.charts.chart;

--- a/js/store.js
+++ b/js/store.js
@@ -1282,7 +1282,8 @@ let AppPageClass = (function(){
 
     function addSteamChart(result) {
         if (this.isDlc()) { return; }
-        if (!SyncedStorage.get("show_steamchart_info", true) || !result.charts || !result.charts.chart || !result.charts.chart.peakall) { return; }
+        if (!SyncedStorage.get("show_steamchart_info", true)) { return; }
+	if (!result.charts || !result.charts.chart || !result.charts.chart.peakall) { return; }
 
         let appid = this.appid;
         let chart = result.charts.chart;


### PR DESCRIPTION
An example: https://store.steampowered.com/app/482400/System_Shock/

AppPageClass.data.charts.chart would be either `[]` or `{ 'current': #, 'peaktoday': #, 'peakall': # }` depending on if the chart has information.