### PR TITLE
Catch JSON errors in LocalData

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -225,7 +225,11 @@ let LocalData = (function(){
     self.get = function(key, defaultValue) {
         let v = localStorage.getItem(key);
         if (!v) return defaultValue;
-        return JSON.parse(v);
+        try {
+            return JSON.parse(v);
+        } catch (err) {
+            return defaultValue;
+        }
     };
 
     self.del = function(key) {


### PR DESCRIPTION
"undefined" doesn't round-trip to JSON, so the bug that required tfedor/Enhanced_Steam#31 to patch can cause `LocalData.get('playback_hd')` to throw