### PR TITLE
Not sure why the event handlers needed to be removed, and this didn't remove them in Chrome

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -2076,9 +2076,6 @@ let SearchPageClass = (function(){
                 row.dataset.addedDate = addedDate;
                 lastNode.insertAdjacentElement("afterend", row);
                 lastNode = row;
-
-                row.removeAttribute("onmouseover");
-                row.removeAttribute("onmouseout");
             }
 
             document.querySelector(".LoadingWrapper").remove();


### PR DESCRIPTION
Removing the event handlers after the row is added to the page didn't cause them to be removed in Chrome. In Firefox they were removed and not replaced, causing the hover popup to stop appearing after the first page.