### PR TITLE
Fixed crash with "Hide 'About' link"

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1334,9 +1334,8 @@ let EnhancedSteam = (function() {
     self.removeAboutMenu = function(){
         if (!SyncedStorage.get("hideaboutmenu")) { return; }
 		
-		let aboutMenu = document.querySelector(".menuitem[href='https://store.steampowered.com/about/']");
-		
-		if (aboutMenu == null) { return; }
+        let aboutMenu = document.querySelector(".menuitem[href='https://store.steampowered.com/about/']");
+        if (aboutMenu == null) { return; }
 		
         aboutMenu.remove();
     };

--- a/js/common.js
+++ b/js/common.js
@@ -1333,7 +1333,12 @@ let EnhancedSteam = (function() {
 
     self.removeAboutMenu = function(){
         if (!SyncedStorage.get("hideaboutmenu")) { return; }
-        document.querySelector(".menuitem[href='https://store.steampowered.com/about/']").remove();
+		
+		let aboutMenu = document.querySelector(".menuitem[href='https://store.steampowered.com/about/']");
+		
+		if (aboutMenu == null) { return; }
+		
+        aboutMenu.remove();
     };
 
     self.addHeaderLinks = function(){


### PR DESCRIPTION
The extension crashed if the "About" menu item, which seems to only appear on certain clients, wasn't found

See #44 for detailed explanation