### PR TITLE
Localization

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -527,6 +527,14 @@ let Localization = (function(){
         if (_promise) { return _promise; }
 
         let currentSteamLanguage = Language.getCurrentSteamLanguage();
+
+        if (currentSteamLanguage !== null) {
+            // TODO Check if value has been explicitly set, as a call to set() every time is probably too much since the user won't change their language very often
+            SyncedStorage.set("language", currentSteamLanguage);
+        } else {
+            currentSteamLanguage = SyncedStorage.get("language");
+        }
+
         let local = Language.getLanguageCode(currentSteamLanguage);
 
         _promise = new Promise(function(resolve, reject) {
@@ -1164,7 +1172,7 @@ let Language = (function(){
             }
         }
 
-        currentSteamLanguage = BrowserHelper.getCookie("Steam_Language") || "english";
+        currentSteamLanguage = BrowserHelper.getCookie("Steam_Language") || null;
         return currentSteamLanguage;
     };
 

--- a/js/common.js
+++ b/js/common.js
@@ -526,8 +526,8 @@ let Localization = (function(){
     self.promise = function(){
         if (_promise) { return _promise; }
 
-        let lang = SyncedStorage.get("language");
-        let local = Language.getLanguageCode(lang);
+        let currentSteamLanguage = Language.getCurrentSteamLanguage();
+        let local = Language.getLanguageCode(currentSteamLanguage);
 
         _promise = new Promise(function(resolve, reject) {
 

--- a/js/common.js
+++ b/js/common.js
@@ -528,8 +528,7 @@ let Localization = (function(){
 
         let currentSteamLanguage = Language.getCurrentSteamLanguage();
 
-        if (currentSteamLanguage !== null) {
-            // TODO Check if value has been explicitly set, as a call to set() every time is probably too much since the user won't change their language very often
+        if (currentSteamLanguage !== null && currentSteamLanguage !== SyncedStorage.get("language")) {
             SyncedStorage.set("language", currentSteamLanguage);
         } else {
             currentSteamLanguage = SyncedStorage.get("language");


### PR DESCRIPTION
Localization now works on both Steam pages and the options page, with the exception that the user has to visit any Steam site first.