### PR TITLE
Add Highlighting to Curator pages

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2555,3 +2555,19 @@ input[type=checkbox].es_dlc_selection:checked + label {
     margin-top:10px;
     text-align:right;
 }
+
+/***************************************
+ * Store curator pages
+ * 
+ **************************************/
+.capsule.smallcapsule .es_overlay_container {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: auto;
+	vertical-align: top;
+}
+.capsule.smallcapsule .es_overlay_container > img {
+	width: 100%;
+}

--- a/js/common.js
+++ b/js/common.js
@@ -1748,6 +1748,12 @@ let EarlyAccess = (function(){
                            ".tab_row",
                            ".browse_tag_game_cap"]);
                 break;
+            case /^\/(?:curator|developer|dlc|publisher)\/.*/.test(window.location.pathname):
+                checkNodes( [
+                    "#curator_avatar_image",
+                    ".capsule",
+                ]);
+                break;
             case /^\/$/.test(window.location.pathname):
                 checkNodes( [".cap",
                            ".special",

--- a/js/common.js
+++ b/js/common.js
@@ -2265,6 +2265,9 @@ let Highlights = (function(){
             "div.recommendation_highlight",	// Recommendation pages
             "div.recommendation_carousel_item",	// Recommendation pages
             "div.friendplaytime_game",		// Recommendation pages
+            "div.recommendation",           // Curator pages and the new DLC pages
+            "div.carousel_items.curator_featured > div", // Carousel items on Curator pages
+            "div.item_ctn",                 // Curator list item
             "div.dlc_page_purchase_dlc",	// DLC page rows
             "div.sale_page_purchase_item",	// Sale pages
             "div.item",						// Sale pages / featured pages

--- a/js/store.js
+++ b/js/store.js
@@ -2873,7 +2873,7 @@ let TabAreaObserver = (function(){
 
     self.observeChanges = function() {
 
-        let tabAreaNode = document.querySelector(".tabarea");
+        let tabAreaNode = document.querySelector(".tabarea, .browse_ctn_background");
         if (!tabAreaNode) { return; }
 
         let observer = new MutationObserver(() => {

--- a/js/store.js
+++ b/js/store.js
@@ -2458,6 +2458,16 @@ let SearchPageClass = (function(){
 })();
 
 
+let CuratorPageClass = (function(){
+    function CuratorPageClass() {
+
+    }
+
+    
+    return CuratorPageClass;
+})();
+
+
 let WishlistPageClass = (function(){
 
     let noteModalTemplate;
@@ -2933,6 +2943,10 @@ let TabAreaObserver = (function(){
 
                     case /^\/sale\/.*/.test(path):
                         (new StorePageClass()).showRegionalPricing("sale");
+                        break;
+
+                    case /^\/(?:curator|developer|dlc|publisher)\/.*/.test(path):
+                        (new CuratorPageClass());
                         break;
 
                     case /^\/wishlist\/(?:id|profiles)\/.+(\/.*)?/.test(path):


### PR DESCRIPTION
Steam recently expanded curator pages to also be used by developers, publishers and as a per-app dlc overview.

Examples:
https://store.steampowered.com/curator/11247776-Co-op-Cowboys/
https://store.steampowered.com/developer/DevolverDigital/
https://store.steampowered.com/publisher/2K/
https://store.steampowered.com/publisher/2K/list/35241
https://store.steampowered.com/dlc/548430/Deep_Rock_Galactic/

The page structure for all of these is almost identical.